### PR TITLE
Fix V3043

### DIFF
--- a/NetworkCommsDotNet/DPSBase/SevenZipLZMACompressor/LzmaEncoder.cs
+++ b/NetworkCommsDotNet/DPSBase/SevenZipLZMACompressor/LzmaEncoder.cs
@@ -1427,7 +1427,7 @@ namespace LZMA
 					{
 						const int kDicLogSizeMaxCompress = 30;
 						if (!(prop is Int32))
-							throw new InvalidParamException(); ;
+							throw new InvalidParamException();
 						Int32 dictionarySize = (Int32)prop;
 						if (dictionarySize < (UInt32)(1 << Base.kDicLogSizeMin) ||
 							dictionarySize > (UInt32)(1 << kDicLogSizeMaxCompress))
@@ -1467,7 +1467,7 @@ namespace LZMA
 							throw new InvalidParamException();
 						Int32 v = (Int32)prop;
 						if (v < 0 || v > (UInt32)Base.kNumLitContextBitsMax)
-							throw new InvalidParamException(); ;
+							throw new InvalidParamException();
 						_numLiteralContextBits = (int)v;
 						break;
 					}


### PR DESCRIPTION
Hello! I'm a member of the Pinguem.ru competition on finding errors in open source projects. A bug, found using PVS-Studio:

 - The code's operational logic does not correspond with its formatting. The statement is indented to the right, but it is always executed. It is possible that curly brackets are missing. NetworkCommsDotNet LzmaEncoder.cs 1430

-  The code's operational logic does not correspond with its formatting. The statement is indented to the right, but it is always executed. It is possible that curly brackets are missing. NetworkCommsDotNet LzmaEncoder.cs 1470