### PR TITLE
Fix V3118

### DIFF
--- a/NetworkCommsDotNet/Connection/ConnectionSendClose.cs
+++ b/NetworkCommsDotNet/Connection/ConnectionSendClose.cs
@@ -469,7 +469,7 @@ namespace NetworkCommsDotNet.Connections
                 //We wait for TCP connections to be established
                 if (ConnectionInfo.ConnectionType == ConnectionType.TCP && ConnectionInfo.ConnectionState != ConnectionState.Established)
                 {
-                    if ((DateTime.Now - ConnectionInfo.ConnectionCreationTime).Milliseconds > NetworkComms.ConnectionEstablishTimeoutMS)
+                    if ((DateTime.Now - ConnectionInfo.ConnectionCreationTime).TotalMilliseconds > NetworkComms.ConnectionEstablishTimeoutMS)
                     {
                         CloseConnection(false, -11);
                         return false;


### PR DESCRIPTION
Hello again from Pinguem.ru competition on finding errors. I found some more bugs with PVS-Studio:

-  Milliseconds component of TimeSpan is used, which does not represent full time interval. Possibly 'TotalMilliseconds' value was intended instead. NetworkCommsDotNet ConnectionSendClose.cs 472